### PR TITLE
Fixed bomb placement constraint, to match code.

### DIFF
--- a/equations/minesweeper_SMT/main_EN.tex
+++ b/equations/minesweeper_SMT/main_EN.tex
@@ -55,8 +55,8 @@ R3 & ? & 1 & . \\
 Then we will try to solve the following system of equations (\emph{RrCc} is cell of row $r$ and column $c$):
 
 \begin{itemize}
-\item R1C2+R2C1+R2C2=1                               (because we placed bomb at R1C1)	
-\item R2C1+R2C2+R3C1=1                               (because we have "1" at R3C2)	
+\item R1C1=1                                         (because we placed bomb at R1C1)	
+\item R2C1+R2C2+R2C3+R3C1+R3C2+R3C3=1                (because we have "1" at R3C2)	
 \item R1C1+R1C2+R1C3+R2C1+R2C2+R2C3+R3C1+R3C2+R3C3=3 (because we have "3" at R2C2)	
 \item R1C2+R1C3+R2C2+R2C3+R3C2+R3C3=0                (because we have "." at R2C3)	
 \item R2C2+R2C3+R3C2+R3C3=0                          (because we have "." at R3C3)


### PR DESCRIPTION
R1C2+R2C1+R2C2=1 doesn't tell us anything
about whether there is a bomb at R1C1 or not;
and doesn't match the python code in the later section.
Also updated constraint about the "1" at R3C2 to be consistent
with other constraints (by including all 6 surrounding squares).